### PR TITLE
Switch from carriage return to backspace

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 // CharSets contains the available character sets
@@ -91,20 +92,20 @@ func (s *Spinner) Start() {
 		return
 	}
 	s.st = running
+
 	go func() {
 		runlock.Lock()
 		defer runlock.Unlock()
-		prevLen := 0
 		for {
 			for i := 0; i < len(s.chars); i++ {
 				select {
 				case <-s.stopChan:
 					return
 				default:
-					fmt.Printf("%s%s%s ", s.Prefix, s.chars[i], s.Suffix)
-					prevLen = len(s.Prefix) + len(s.chars[i]) + len(s.Suffix) + 1
+					out := fmt.Sprintf("%s%s%s ", s.Prefix, s.chars[i], s.Suffix)
+					fmt.Print(out)
 					time.Sleep(s.Delay)
-					erase(prevLen)
+					erase(out)
 				}
 			}
 		}
@@ -112,7 +113,8 @@ func (s *Spinner) Start() {
 	return
 }
 
-func erase(n int) {
+func erase(a string) {
+	n := utf8.RuneCountInString(a)
 	for i := 0; i < n; i++ {
 		fmt.Printf("\b")
 	}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -15,6 +15,7 @@
 package spinner
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -120,4 +121,17 @@ func TestMultiple(t *testing.T) {
 	a.Stop()
 	time.Sleep(3 * time.Second)
 	b.Stop()
+}
+
+// TestBackspace proves that the correct number of characters are removed.
+func TestBackspace(t *testing.T) {
+	// Because of buffering of output and time weirdness, somethings
+	// are broken for an indeterminant reason without a wait
+	time.Sleep(75 * time.Millisecond)
+	fmt.Println()
+	s := New(CharSets[0], 100*time.Millisecond)
+	s.Start()
+	fmt.Print("This is on the same line as the spinner: ")
+	time.Sleep(4 * time.Second)
+	s.Stop()
 }


### PR DESCRIPTION
Allows for printing arbitrary text through normal means on the same line
as a spinner with expected behavior.

Also included the removal of start error as discussed.
