### PR TITLE
use color.Output instead of os.Stdout

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -105,7 +105,7 @@ func New(c []string, t time.Duration) *Spinner {
 		Delay:    t,
 		stopChan: make(chan bool, 1),
 		color:    color.New(color.FgWhite).SprintFunc(),
-		w:        os.Stdout,
+		w:        color.Output,
 	}
 	s.UpdateCharSet(c)
 	return s

--- a/spinner.go
+++ b/spinner.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"time"
 	"unicode/utf8"


### PR DESCRIPTION
ref: https://github.com/fatih/color/blob/master/color.go#L124

to support windows terminal/console the color package wraps the os.Stdout in an AnsiColorOurput which allows for the color code to support windows as well as the various unixes.