### PR TITLE
Fix too many backspaces

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -17,10 +17,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"time"
-	"unicode/utf8"
 
 	"github.com/fatih/color"
 )
@@ -105,7 +103,7 @@ func New(c []string, t time.Duration) *Spinner {
 		Delay:    t,
 		stopChan: make(chan bool, 1),
 		color:    color.New(color.FgWhite).SprintFunc(),
-		w:        os.Stdout,
+		w:        color.Output,
 	}
 	s.UpdateCharSet(c)
 	return s
@@ -124,22 +122,14 @@ func (s *Spinner) Start() {
 				case <-s.stopChan:
 					return
 				default:
+					fmt.Fprintf(s.w, "\r")
 					out := fmt.Sprintf("%s%s%s ", s.Prefix, s.color(s.chars[i]), s.Suffix)
 					fmt.Fprint(s.w, out)
 					time.Sleep(s.Delay)
-					erase(s.w, out)
 				}
 			}
 		}
 	}()
-}
-
-// erase deletes written characters
-func erase(w io.Writer, a string) {
-	n := utf8.RuneCountInString(a)
-	for i := 0; i < n; i++ {
-		fmt.Fprintf(w, "\b")
-	}
 }
 
 // Color will set the struct field for the given color to be used


### PR DESCRIPTION
I replaced the backspaces output with a single carriage return character (\r) without a newline (\n) causing the shell to go back to the beginning of the existing line so that each successive output will overwrite the previous one. One downside to this method is that each slice in a spinner definifiton needs to be the same length as all the others in the same spinner style.