### PR TITLE
Erase with overwrite

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -179,8 +179,10 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 // Caller must already hold s.lock.
 func (s *Spinner) erase() {
 	n := utf8.RuneCountInString(s.lastOutput)
-	for i := 0; i < n; i++ {
-		fmt.Fprintf(s.Writer, "\b")
+	for _, c := range []string{"\b", " ", "\b"} {
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(s.Writer, c)
+		}
 	}
 	s.lastOutput = ""
 }


### PR DESCRIPTION
`\b` on many (most?) contemporary terminal devices is not a true erase.  On these terminals, `\b` (`^H`) will only move the cursor one position to the left without actually deleting any characters.

(Compare with `^?`, which on most VT100-derived terminal devices, should map to a true left-erase.)

This commit adds a three-pass overwrite to `erase()`:

  1. First pass with `\b` to wind the cursor back to the beginning.
  2. Second pass with spaces to wipe stale spinner output.
  3. Third pass with `\b` again to reset cursor position.

On systems that actually implement erasure on `^H`, pass (1) will be sufficient in itself, and passes (2) and (3) should look like no-ops. (I'm not sure what systems fall into this category -- maybe Windows?)