### PR TITLE
made validColor use map

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -29,16 +29,23 @@ import (
 var errInvalidColor = errors.New("invalid color")
 
 // validColors holds an array of the only colors allowed
-var validColors = []string{"red", "green", "yellow", "blue", "magenta", "cyan", "white"}
+var validColors = map[string]bool{
+	"red":     true,
+	"green":   true,
+	"yellow":  true,
+	"blue":    true,
+	"magenta": true,
+	"cyan":    true,
+	"white":   true,
+}
 
 // validColor will make sure the given color is actually allowed
 func validColor(c string) bool {
-	for _, i := range validColors {
-		if c == i {
-			return true
-		}
+	valid := false
+	if validColors[c] {
+		valid = true
 	}
-	return false
+	return valid
 }
 
 // Spinner struct to hold the provided options


### PR DESCRIPTION
The valid color check was iterating at most n times over the _validColors_ slice to determine if the color was valid.  This is updated to use a map, so the lookup for a valid color is in constant time (O(1) rather than O(n)).

All automated tests pass.