### PR TITLE
Updated Color method to return an error if the color name given is not valid, else return nil, 

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -148,14 +148,12 @@ func (s *Spinner) Reverse() {
 
 // Color will set the struct field for the given color to be used
 func (s *Spinner) Color(c string) error {
-	var colorError error
-	if validColor(c) {
-		s.color = color.New(colorAttributeMap[c]).SprintFunc()
-		s.Restart()
-	} else {
-		colorError = errInvalidColor
+	if !validColor(c) {
+		return errInvalidColor
 	}
-	return colorError
+	s.color = color.New(colorAttributeMap[c]).SprintFunc()
+	s.Restart()
+	return nil
 }
 
 // UpdateSpeed will set the indicator delay to the given value

--- a/spinner.go
+++ b/spinner.go
@@ -39,6 +39,17 @@ var validColors = map[string]bool{
 	"white":   true,
 }
 
+// returns a valid color's foreground text color attribute
+var colorAttributeMap = map[string]color.Attribute{
+	"red":     color.FgRed,
+	"green":   color.FgGreen,
+	"yellow":  color.FgYellow,
+	"blue":    color.FgBlue,
+	"magenta": color.FgMagenta,
+	"cyan":    color.FgCyan,
+	"white":   color.FgWhite,
+}
+
 // validColor will make sure the given color is actually allowed
 func validColor(c string) bool {
 	valid := false
@@ -137,34 +148,14 @@ func (s *Spinner) Reverse() {
 
 // Color will set the struct field for the given color to be used
 func (s *Spinner) Color(c string) error {
+	var colorError error
 	if validColor(c) {
-		switch c {
-		case "red":
-			s.color = color.New(color.FgRed).SprintFunc()
-			s.Restart()
-		case "yellow":
-			s.color = color.New(color.FgYellow).SprintFunc()
-			s.Restart()
-		case "green":
-			s.color = color.New(color.FgGreen).SprintFunc()
-			s.Restart()
-		case "magenta":
-			s.color = color.New(color.FgMagenta).SprintFunc()
-			s.Restart()
-		case "blue":
-			s.color = color.New(color.FgBlue).SprintFunc()
-			s.Restart()
-		case "cyan":
-			s.color = color.New(color.FgCyan).SprintFunc()
-			s.Restart()
-		case "white":
-			s.color = color.New(color.FgWhite).SprintFunc()
-			s.Restart()
-		default:
-			return errInvalidColor
-		}
+		s.color = color.New(colorAttributeMap[c]).SprintFunc()
+		s.Restart()
+	} else {
+		colorError = errInvalidColor
 	}
-	return nil
+	return colorError
 }
 
 // UpdateSpeed will set the indicator delay to the given value

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -190,7 +190,7 @@ func TestColorError(t *testing.T) {
 		t.Error("Color function did not return an error when given an invalid color.")
 	}
 
-	if s.Color(validColorName) == errInvalidColor {
+	if s.Color(validColorName) != nil {
 		t.Error("Color function returned an error when given a valid color.")
 	}
 }

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -178,6 +178,23 @@ func TestBackspace(t *testing.T) {
 	s.Stop()
 }
 
+// TestColorError tests that if an invalid color string is passed to the Color
+// function, the invalid color error is returned
+func TestColorError(t *testing.T) {
+	s := New(CharSets[0], 100*time.Millisecond)
+
+	invalidColorName := "bluez"
+	validColorName := "green"
+
+	if s.Color(invalidColorName) != errInvalidColor {
+		t.Error("Color function did not return an error when given an invalid color.")
+	}
+
+	if s.Color(validColorName) == errInvalidColor {
+		t.Error("Color function returned an error when given a valid color.")
+	}
+}
+
 /*
 Benchmarks
 */

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -187,11 +187,11 @@ func TestColorError(t *testing.T) {
 	validColorName := "green"
 
 	if s.Color(invalidColorName) != errInvalidColor {
-		t.Error("Color function did not return an error when given an invalid color.")
+		t.Error("Color method did not return an error when given an invalid color.")
 	}
 
 	if s.Color(validColorName) != nil {
-		t.Error("Color function returned an error when given a valid color.")
+		t.Error("Color method did not return nil when given a valid color name.")
 	}
 }
 


### PR DESCRIPTION
- added map that maps string-representation of color to it's foreground text color attribute, use this in the Color method so if the string passed in represents a valid color, the correct attribute is returned or else an error is returned
- test case TestColorError was added to test against both cases of valid and invalid color name passed into Color method
- fixes #35