### PR TITLE
[WIP] Switch to "\033[2K\r" in erase

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/fatih/color"
 )
@@ -174,12 +173,7 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 //
 // Caller must already hold s.lock.
 func (s *Spinner) erase() {
-	n := utf8.RuneCountInString(s.lastOutput)
-	for _, c := range []string{"\b", " ", "\b"} {
-		for i := 0; i < n; i++ {
-			fmt.Fprintf(s.Writer, c)
-		}
-	}
+	fmt.Fprintf(s.Writer, "\033[2K\r")
 	s.lastOutput = ""
 }
 


### PR DESCRIPTION
See #37
## Status
- Successfully overwrides previous line
- Tests fail

## Questions
- Is `lastOutput` necessary, or can I remove it?
- Why do the tests fail? I am having trouble understanding the error:
  ```
  === RUN   TestNew
  --- PASS: TestNew (0.00s)
  === RUN   TestStart
  --- PASS: TestStart (3.10s)
  === RUN   TestStop
  --- PASS: TestStop (0.90s)
  === RUN   TestRestart
  --- FAIL: TestRestart (0.45s)
          spinner_test.go:106: Expected ==, got
                  []byte{0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa2, 0x1b, 0x5b, 0x30, 0x6d
  , 0x20, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa3, 0x1b, 0x5b, 0x30, 0x6d, 0x20, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0
  x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa4, 0x1b, 0x5b, 0x30, 0x6d, 0x20, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa5, 0x1
  b, 0x5b, 0x30, 0x6d, 0x20, 0x1b, 0x5b} !=
                  []byte{0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa2, 0x1b, 0x5b, 0x30, 0x6d, 0x20, 0x1b
  , 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa3, 0x1b, 0x5b, 0x30, 0x6d, 0x20, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0
  x36, 0x6d, 0xe2, 0x97, 0xa4, 0x1b, 0x5b, 0x30, 0x6d, 0x20, 0x1b, 0x5b, 0x32, 0x4b, 0xd, 0x1b, 0x5b, 0x33, 0x36, 0x6d, 0xe2, 0x97, 0xa5, 0x1b, 0x5b, 0x3
  0, 0x6d, 0x20, 0x1b, 0x5b, 0x32, 0x4b, 0xd}
  === RUN   TestReverse
  --- PASS: TestReverse (9.00s)
  === RUN   TestUpdateSpeed
  --- PASS: TestUpdateSpeed (0.00s)
  === RUN   TestUpdateCharSet
  --- PASS: TestUpdateCharSet (0.00s)
  === RUN   TestGenerateNumberSequence
  --- PASS: TestGenerateNumberSequence (0.00s)
          spinner_test.go:160: In:  100
          spinner_test.go:161: Out:  100
  === RUN   TestBackspace

  --- PASS: TestBackspace (3.08s)
  === RUN   TestColorError
  --- PASS: TestColorError (0.00s)
  FAIL
  exit status 1
  FAIL    _/home/caleb/Programming/spinner        16.538s  
  ```
