### PR TITLE
Promote example binary comment to package comment

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -1,8 +1,5 @@
+// Example application that uses all of the available API options.
 package main
-
-// Example application that uses all of the available API
-// options
-
 import (
 	"log"
 	"time"


### PR DESCRIPTION
It's a trivial change, but makes my linter happy by providing a package comment
for the example application.