### PR TITLE
Actually let the user retrieve the spinner's status

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ s := spinner.New(setOfDigits, 100*time.Millisecond)
 ## Get spinner status
 
 ```Go
-fmt.Println(s.ST)
+fmt.Println(s.Active())
 ```
 
 ## Unix pipe and redirect

--- a/spinner.go
+++ b/spinner.go
@@ -87,6 +87,11 @@ func New(cs []string, d time.Duration) *Spinner {
 	}
 }
 
+// Active will return whether or not the spinner is currently active
+func (s *Spinner) Active() bool {
+	return s.active
+}
+
 // Start will start the indicator
 func (s *Spinner) Start() {
 	if s.active {

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -64,6 +64,22 @@ func TestStart(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
+// TestActive will verify we can tell when a spinner is running
+func TestActive(t *testing.T) {
+	s := New(CharSets[1], 100*time.Millisecond)
+	if s.Active() {
+		t.Error("expected a new spinner to not be active")
+	}
+	s.Start()
+	if !s.Active() {
+		t.Error("expected a started spinner to be active")
+	}
+	s.Stop()
+	if s.Active() {
+		t.Error("expected a stopped spinner to be active")
+	}
+}
+
 // TestStop will verify a spinner can be stopped
 func TestStop(t *testing.T) {
 	p, out := withOutput(CharSets[14], 100*time.Millisecond)


### PR DESCRIPTION
It appears the ST attribute was removed at some point.  This adds an Active() function which simple returns whether or not the spinner is currently active.