### PR TITLE
Added bold / italics / background colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ index | character set
 * Update the spinner character set
 * Update the spinner speed
 * Prefix or append text
-* Change spinner color
+* Change spinner color, background, and text attributes such as bold / italics
 * Get spinner status
 * Chain, pipe, redirect output
 * Output final string on spinner/indicator completion
@@ -143,6 +143,84 @@ s.Suffix = "  :appended text" // Append text after the spinner
 
 ```Go
 s.Color("red") // Set the spinner color to red
+```
+
+You can specify both the background and foreground color, as well as additional attributes such as `bold` or `underline`.
+
+```Go
+s.Color("red", "bold") // Set the spinner color to a bold red
+```
+
+Or to set the background to black, the foreground to a bold red:
+
+```Go
+s.Color("bgBlack", "bold", "fgRed")
+```
+
+Below is the full color and attribute list:
+
+```
+// default colors
+red
+black
+green
+yellow
+blue
+magenta
+cyan
+white
+
+// attributes
+reset
+bold
+faint
+italic
+underline
+blinkslow
+blinkrapid
+reversevideo
+concealed
+crossedout
+
+// foreground text
+fgBlack
+fgRed
+fgGreen
+fgYellow
+fgBlue
+fgMagenta
+fgCyan
+fgWhite
+
+// foreground Hi-Intensity text
+fgHiBlack
+fgHiRed
+fgHiGreen
+fgHiYellow
+fgHiBlue
+fgHiMagenta
+fgHiCyan
+fgHiWhite
+
+// background text
+bgBlack
+bgRed
+bgGreen
+bgYellow
+bgBlue
+bgMagenta
+bgCyan
+bgWhite
+
+// background Hi-Intensity text
+bgHiBlack
+bgHiRed
+bgHiGreen
+bgHiYellow
+bgHiBlue
+bgHiMagenta
+bgHiCyan
+bgHiWhite
 ```
 
 ## Generate a sequence of numbers

--- a/spinner.go
+++ b/spinner.go
@@ -30,6 +30,8 @@ var errInvalidColor = errors.New("invalid color")
 
 // validColors holds an array of the only colors allowed
 var validColors = map[string]bool{
+	// default colors for backwards compatibility
+	"black":   true,
 	"red":     true,
 	"green":   true,
 	"yellow":  true,
@@ -37,10 +39,64 @@ var validColors = map[string]bool{
 	"magenta": true,
 	"cyan":    true,
 	"white":   true,
+
+	// attributes
+	"reset":        true,
+	"bold":         true,
+	"faint":        true,
+	"italic":       true,
+	"underline":    true,
+	"blinkslow":    true,
+	"blinkrapid":   true,
+	"reversevideo": true,
+	"concealed":    true,
+	"crossedout":   true,
+
+	// foreground text
+	"fgBlack":   true,
+	"fgRed":     true,
+	"fgGreen":   true,
+	"fgYellow":  true,
+	"fgBlue":    true,
+	"fgMagenta": true,
+	"fgCyan":    true,
+	"fgWhite":   true,
+
+	// foreground Hi-Intensity text
+	"fgHiBlack":   true,
+	"fgHiRed":     true,
+	"fgHiGreen":   true,
+	"fgHiYellow":  true,
+	"fgHiBlue":    true,
+	"fgHiMagenta": true,
+	"fgHiCyan":    true,
+	"fgHiWhite":   true,
+
+	// background text
+	"bgBlack":   true,
+	"bgRed":     true,
+	"bgGreen":   true,
+	"bgYellow":  true,
+	"bgBlue":    true,
+	"bgMagenta": true,
+	"bgCyan":    true,
+	"bgWhite":   true,
+
+	// background Hi-Intensity text
+	"bgHiBlack":   true,
+	"bgHiRed":     true,
+	"bgHiGreen":   true,
+	"bgHiYellow":  true,
+	"bgHiBlue":    true,
+	"bgHiMagenta": true,
+	"bgHiCyan":    true,
+	"bgHiWhite":   true,
 }
 
 // returns a valid color's foreground text color attribute
 var colorAttributeMap = map[string]color.Attribute{
+	// default colors for backwards compatibility
+	"black":   color.FgBlack,
 	"red":     color.FgRed,
 	"green":   color.FgGreen,
 	"yellow":  color.FgYellow,
@@ -48,6 +104,58 @@ var colorAttributeMap = map[string]color.Attribute{
 	"magenta": color.FgMagenta,
 	"cyan":    color.FgCyan,
 	"white":   color.FgWhite,
+
+	// attributes
+	"reset":        color.Reset,
+	"bold":         color.Bold,
+	"faint":        color.Faint,
+	"italic":       color.Italic,
+	"underline":    color.Underline,
+	"blinkslow":    color.BlinkSlow,
+	"blinkrapid":   color.BlinkRapid,
+	"reversevideo": color.ReverseVideo,
+	"concealed":    color.Concealed,
+	"crossedout":   color.CrossedOut,
+
+	// foreground text colors
+	"fgBlack":   color.FgBlack,
+	"fgRed":     color.FgRed,
+	"fgGreen":   color.FgGreen,
+	"fgYellow":  color.FgYellow,
+	"fgBlue":    color.FgBlue,
+	"fgMagenta": color.FgMagenta,
+	"fgCyan":    color.FgCyan,
+	"fgWhite":   color.FgWhite,
+
+	// foreground Hi-Intensity text colors
+	"fgHiBlack":   color.FgHiBlack,
+	"fgHiRed":     color.FgHiRed,
+	"fgHiGreen":   color.FgHiGreen,
+	"fgHiYellow":  color.FgHiYellow,
+	"fgHiBlue":    color.FgHiBlue,
+	"fgHiMagenta": color.FgHiMagenta,
+	"fgHiCyan":    color.FgHiCyan,
+	"fgHiWhite":   color.FgHiWhite,
+
+	// background text colors
+	"bgBlack":   color.BgBlack,
+	"bgRed":     color.BgRed,
+	"bgGreen":   color.BgGreen,
+	"bgYellow":  color.BgYellow,
+	"bgBlue":    color.BgBlue,
+	"bgMagenta": color.BgMagenta,
+	"bgCyan":    color.BgCyan,
+	"bgWhite":   color.BgWhite,
+
+	// background Hi-Intensity text colors
+	"bgHiBlack":   color.BgHiBlack,
+	"bgHiRed":     color.BgHiRed,
+	"bgHiGreen":   color.BgHiGreen,
+	"bgHiYellow":  color.BgHiYellow,
+	"bgHiBlue":    color.BgHiBlue,
+	"bgHiMagenta": color.BgHiMagenta,
+	"bgHiCyan":    color.BgHiCyan,
+	"bgHiWhite":   color.BgHiWhite,
 }
 
 // validColor will make sure the given color is actually allowed
@@ -152,11 +260,20 @@ func (s *Spinner) Reverse() {
 }
 
 // Color will set the struct field for the given color to be used
-func (s *Spinner) Color(c string) error {
-	if !validColor(c) {
-		return errInvalidColor
+func (s *Spinner) Color(colors ...string) error {
+
+	colorAttributes := make([]color.Attribute, len(colors))
+
+	// Verify colours are valid and place the appropriate attribute in the array
+	for index, c := range colors {
+		if !validColor(c) {
+			return errInvalidColor
+		}
+
+		colorAttributes[index] = colorAttributeMap[c]
 	}
-	s.color = color.New(colorAttributeMap[c]).SprintFunc()
+
+	s.color = color.New(colorAttributes...).SprintFunc()
 	s.Restart()
 	return nil
 }


### PR DESCRIPTION
This PR allows for changing the background color, as well as all the other ANSI attributes defined in https://github.com/fatih/color

This maintains the old API interface so it shouldn't be a breaking change.

```Go
s.Color("red") // Set the spinner color to red
```

You can just add more arguments to the Color function:

```Go
s.Color("red", "bold") // Set the spinner color to a bold red
```

Or explicit background and foreground colors:

```Go
s.Color("bgBlack", "bold", "fgRed")
```
