### PR TITLE
fix control characters instead of spinner on Windows

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -218,7 +218,7 @@ func (s *Spinner) Start() {
 					return
 				default:
 					s.lock.Lock()
-					// s.erase()
+					s.erase()
 					var outColor string
 					if runtime.GOOS == "windows" {
 						if s.Writer == os.Stderr {
@@ -251,6 +251,9 @@ func (s *Spinner) Stop() {
 		s.erase()
 		if s.FinalMSG != "" {
 			fmt.Fprintf(s.Writer, s.FinalMSG)
+		}
+		if runtime.GOOS == "windows" {
+			fmt.Fprintf(s.Writer, "\r")
 		}
 		s.stopChan <- struct{}{}
 	}
@@ -309,8 +312,17 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 // Caller must already hold s.lock.
 func (s *Spinner) erase() {
 	n := utf8.RuneCountInString(s.lastOutput)
+	if runtime.GOOS == "windows" {
+		clearString := "\r"
+		for i := 0; i < n; i++ {
+			clearString += " "
+		}
+		fmt.Fprintf(s.Writer, clearString)
+		return
+	}
 	del, _ := hex.DecodeString("7f")
 	for _, c := range []string{
+		"\r",
 		"\b",
 		string(del),
 		"\b",

--- a/spinner.go
+++ b/spinner.go
@@ -319,7 +319,6 @@ func (s *Spinner) erase() {
 	}
 	del, _ := hex.DecodeString("7f")
 	for _, c := range []string{
-		"\r",
 		"\b",
 		string(del),
 		"\b",

--- a/spinner.go
+++ b/spinner.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -216,8 +218,17 @@ func (s *Spinner) Start() {
 					return
 				default:
 					s.lock.Lock()
-					s.erase()
-					outColor := fmt.Sprintf("%s%s%s ", s.Prefix, s.color(s.chars[i]), s.Suffix)
+					// s.erase()
+					var outColor string
+					if runtime.GOOS == "windows" {
+						if s.Writer == os.Stderr {
+							outColor = fmt.Sprintf("\r%s%s%s ", s.Prefix, s.chars[i], s.Suffix)
+						} else {
+							outColor = fmt.Sprintf("\r%s%s%s ", s.Prefix, s.color(s.chars[i]), s.Suffix)
+						}
+					} else {
+						outColor = fmt.Sprintf("%s%s%s ", s.Prefix, s.color(s.chars[i]), s.Suffix)
+					}
 					outPlain := fmt.Sprintf("%s%s%s ", s.Prefix, s.chars[i], s.Suffix)
 					fmt.Fprint(s.Writer, outColor)
 					s.lastOutput = outPlain

--- a/spinner.go
+++ b/spinner.go
@@ -252,9 +252,6 @@ func (s *Spinner) Stop() {
 		if s.FinalMSG != "" {
 			fmt.Fprintf(s.Writer, s.FinalMSG)
 		}
-		if runtime.GOOS == "windows" {
-			fmt.Fprintf(s.Writer, "\r")
-		}
 		s.stopChan <- struct{}{}
 	}
 }


### PR DESCRIPTION
I was having the same issue as in #52, seeing control characters in Windows. 

It turns out an easy fix is to use the line feed character `\r` to process the lines in Windows.

Another issue I had though, was I wanted to use the `os.Stderr` and the coloring had a bad time dealing with this, so I added another if-statement to take out coloring if using `os.Stderr`.