### PR TITLE
eliminate a data race from spinner.Start()

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -237,10 +237,13 @@ func (s *Spinner) Active() bool {
 
 // Start will start the indicator
 func (s *Spinner) Start() {
+	s.lock.Lock()
 	if s.active {
+		s.lock.Unlock()
 		return
 	}
 	s.active = true
+	s.lock.Unlock()
 
 	go func() {
 		for {


### PR DESCRIPTION
compiling another project with `-race` enabled lead me to this race, added locking around the active flag to avoid this.