### PR TITLE
Lock mutex when changing color

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -320,7 +320,9 @@ func (s *Spinner) Color(colors ...string) error {
 		colorAttributes[index] = colorAttributeMap[c]
 	}
 
+	s.lock.Lock()
 	s.color = color.New(colorAttributes...).SprintFunc()
+	s.lock.Unlock()
 	s.Restart()
 	return nil
 }


### PR DESCRIPTION
Ref linkerd/linkerd2#2264

We're using `Color()` to restart the spinner, and when running with `-race`, sometimes we get a data race that starts something like this:

```
WARNING: DATA RACE                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
Write at 0x00c0001aa4e0 by main goroutine:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  github.com/linkerd/linkerd2/vendor/github.com/briandowns/spinner.(*Spinner).Color()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
      /home/alpeb/go/src/github.com/linkerd/linkerd2/vendor/github.com/briandowns/spinner/spinner.go:323 +0x3ef
...
```
