### PR TITLE
Fix for erroneous whitespace after stopping a spinner on windows

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -372,11 +372,13 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 func (s *Spinner) erase() {
 	n := utf8.RuneCountInString(s.lastOutput)
 	if runtime.GOOS == "windows" {
-		clearString := "\r"
+		clearString := ""
 		for i := 0; i < n; i++ {
 			clearString += " "
 		}
+		clearString += "\r"
 		fmt.Fprintf(s.Writer, clearString)
+		s.lastOutput = ""
 		return
 	}
 	del, _ := hex.DecodeString("7f")


### PR DESCRIPTION
I'm not too familiar with how this works on windows, but this change adds the carriage return to the end, and resets the lastOutput variable for Windows as well since it was short circuiting early.

Previously to this change I would get whitespace "left over" after stopping the Spinner, leaving the next message to be offset to the right.