### PR TITLE
Erase written chars starting from the beginning of line on windows

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -277,7 +277,7 @@ func (s *Spinner) Start() {
 					if !s.active {
 						return
 					}
-					
+
 					var outColor string
 					if runtime.GOOS == "windows" {
 						if s.Writer == os.Stderr {
@@ -373,7 +373,7 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 func (s *Spinner) erase() {
 	n := utf8.RuneCountInString(s.lastOutput)
 	if runtime.GOOS == "windows" {
-		var clearString string
+		clearString := "\r"
 		for i := 0; i < n; i++ {
 			clearString += " "
 		}


### PR DESCRIPTION
The erase() method writes `clearString` from the end of the line on Windows. This change forces `clearString` to be written from the beginning of the line. This way the previously written characters are replaced with spaces on Windows.