### PR TITLE
Avoid `erase()` if spinner is not active

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -285,11 +285,11 @@ func (s *Spinner) Start() {
 				case <-s.stopChan:
 					return
 				default:
-					s.mu.Lock()
-					s.erase()
 					if !s.active {
 						return
 					}
+					s.mu.Lock()
+					s.erase()
 
 					if s.PreUpdate != nil {
 						s.PreUpdate(s)


### PR DESCRIPTION
Calling Stop already does an `erase()` and sets `active = false`, so the goroutine should not additionally `erase()` for an inactive spinner.

Additionally, avoid locking the mutex for an inactive spinner because nothing will be written, and previously the mutex remained locked indefinitely.

Fixes #91