### PR TITLE
Fix data race with struct access after calling `Stop()`

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -285,10 +285,11 @@ func (s *Spinner) Start() {
 				case <-s.stopChan:
 					return
 				default:
+					s.mu.Lock()
 					if !s.active {
+						s.mu.Unlock()
 						return
 					}
-					s.mu.Lock()
 					s.erase()
 
 					if s.PreUpdate != nil {


### PR DESCRIPTION
We need to obtain a lock before accessing `s.active` because `Stop()` might write to it at the same time.

Followup to #92, where I attempted to fix a Writer-related data race, but left code the vulnerable to race conditions around struct property access.