### PR TITLE
Allow `%` characters in FinalMSG

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -14,13 +14,13 @@
 package spinner
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -393,20 +393,13 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 func (s *Spinner) erase() {
 	n := utf8.RuneCountInString(s.lastOutput)
 	if runtime.GOOS == "windows" {
-		clearString := "\r"
-		for i := 0; i < n; i++ {
-			clearString += " "
-		}
-		clearString += "\r"
-		fmt.Fprintf(s.Writer, clearString)
+		clearString := "\r" + strings.Repeat(" ", n) + "\r"
+		fmt.Fprint(s.Writer, clearString)
 		s.lastOutput = ""
 		return
 	}
-	del, _ := hex.DecodeString("7f")
-	for _, c := range []string{"\b", string(del), "\b", "\033[K"} { // "\033[K" for macOS Terminal
-		for i := 0; i < n; i++ {
-			fmt.Fprintf(s.Writer, c)
-		}
+	for _, c := range []string{"\b", "\127", "\b", "\033[K"} { // "\033[K" for macOS Terminal
+		fmt.Fprint(s.Writer, strings.Repeat(c, n))
 	}
 	s.lastOutput = ""
 }

--- a/spinner.go
+++ b/spinner.go
@@ -334,7 +334,7 @@ func (s *Spinner) Stop() {
 		}
 		s.erase()
 		if s.FinalMSG != "" {
-			fmt.Fprintf(s.Writer, s.FinalMSG)
+			fmt.Fprint(s.Writer, s.FinalMSG)
 		}
 		s.stopChan <- struct{}{}
 	}


### PR DESCRIPTION
FinalMSG is not intended to be a format string for `printf`, so it should not be passed as such.

Also removes printf and simplifies `erase()` implementation.

Ref. #57