### PR TITLE
Fix output on iTerm in macOS

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -408,7 +408,7 @@ func (s *Spinner) erase() {
 			fmt.Fprintf(s.Writer, c)
 		}
 	}
-	fmt.Fprintf(s.Writer, "\033[K") // erases to end of line
+	fmt.Fprintf(s.Writer, "\r\033[K") // erases to end of line
 	s.lastOutput = ""
 }
 


### PR DESCRIPTION
Hi there -

I pulled the library in tonight and found that it was failing to clear the line output when updating the spinner on iTerm. Within VSCode and the default macOS it works fine but within iTerm it fails to clear the line and just appends the text.

Looking at other libraries as a reference, there is a missing `\r` on the clear line escape sequence which I have added.

Here's a video of the before and after: https://www.dropbox.com/t/cXf0fRCkfYwnDf49