### PR TITLE
Print cursor esc code sequence to the configured writer

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -273,7 +273,7 @@ func (s *Spinner) Start() {
 	}
 	if s.HideCursor && runtime.GOOS != "windows" {
 		// hides the cursor
-		fmt.Print("\033[?25l")
+		fmt.Fprint(s.Writer, "\033[?25l")
 	}
 	s.active = true
 	s.mu.Unlock()
@@ -331,7 +331,7 @@ func (s *Spinner) Stop() {
 		s.active = false
 		if s.HideCursor && runtime.GOOS != "windows" {
 			// makes the cursor visible
-			fmt.Print("\033[?25h")
+			fmt.Fprint(s.Writer, "\033[?25h")
 		}
 		s.erase()
 		if s.FinalMSG != "" {


### PR DESCRIPTION
Cursor escape code sequence is always printed in `StdOut` at the moment instead of the configured writer.