### PR TITLE
Fix unnecessary character output on macOS

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -396,9 +396,6 @@ func (s *Spinner) erase() {
 		s.lastOutput = ""
 		return
 	}
-	for _, c := range []string{"\b", "\127", "\b", "\033[K"} { // "\033[K" for macOS Terminal
-		fmt.Fprint(s.Writer, strings.Repeat(c, n))
-	}
 	fmt.Fprintf(s.Writer, "\r\033[K") // erases to end of line
 	s.lastOutput = ""
 }


### PR DESCRIPTION
fix #110 on **macOS only**

It has been tested with my project (https://github.com/Dreamacro/go-check) on the following terminals:

* VScode Terminal
* JetBrains Terminal (Goland)
* iTerm2
* Terminal.app

macOS version: 11.4.0

I don't know what this hack was added for, waiting for @briandowns to confirm