### PR TITLE
fix flashing during erase() on windows terminal

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -405,7 +405,7 @@ func (s *Spinner) erase() {
 		s.lastOutput = ""
 		return
 	}
-	fmt.Fprintf(s.Writer, "\r\033[K") // erases to end of line
+	fmt.Fprintf(s.Writer, "\033[K") // erases to end of line
 	s.lastOutput = ""
 }
 


### PR DESCRIPTION
This is a fix for windows terminal.
You can see when they implemented this feature here https://github.com/microsoft/terminal/pull/5181/files#diff-e3429f3447a1f078e953e22ed6556dfbffd1c584ec362f1be455d98589c38e79R108

before:

https://emu.bz/before.webm

after:

https://emu.bz/after.webm


for some reason this did not work with WSL in windows terminal, but it never worked in that situation anyway. 
I can't detect if it's in windows terminal on WSL because the WT_TERMINAL env variable doesn't exist in that environment, but i could check for /etc/wsl.conf if needed. If it is in windows terminal on WSL, it can't use the cursor position escape sequence in combination with a carriage return in the clear function.
```
fmt.Fprintf(s.Writer, "\r\033[K") // erases to end of line
```
would need to be either
```
fmt.Fprintf(s.Writer, "\r") // erases to end of line
```
or
```
fmt.Fprintf(s.Writer, "\033[K") // erases to end of line
```
in that environment

in a975c3cb7b747cb51eac2c47e3baf29e122eb551, simply writing `\033[K` instead of `\r\033[K` in the clear function seems to do the trick, but I think I will need some verification that this works as intended in native linux environments.