### PR TITLE
replace \033[K with \r in clear

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -405,7 +405,7 @@ func (s *Spinner) erase() {
 		s.lastOutput = ""
 		return
 	}
-	fmt.Fprintf(s.Writer, "\033[K") // erases to end of line
+	fmt.Fprintf(s.Writer, "\r") // erases to end of line
 	s.lastOutput = ""
 }
 


### PR DESCRIPTION
seems that in WSL it doesn't actually clear the line when just using \033[K, but it does with \r. In Powershell, however it does clear the line.

![image](https://user-images.githubusercontent.com/1855905/120707473-98e18180-c477-11eb-8204-e35c13d68488.png)

this fixes that