### PR TITLE
Update TestRestart - CrossOS Passing & More Consistent

### DIFF
--- a/spinner_test.go
+++ b/spinner_test.go
@@ -106,12 +106,12 @@ func TestStop(t *testing.T) {
 
 // TestRestart will verify a spinner can be stopped and started again
 func TestRestart(t *testing.T) {
-	s, out := withOutput(CharSets[4], 20*time.Millisecond)
+	s, out := withOutput(CharSets[4], 40*time.Millisecond)
 
 	s.Start()
-	time.Sleep(75 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 	s.Restart()
-	time.Sleep(75 * time.Millisecond)
+	time.Sleep(158 * time.Millisecond)
 	s.Stop()
 	time.Sleep(10 * time.Millisecond)
 

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -106,25 +106,21 @@ func TestStop(t *testing.T) {
 
 // TestRestart will verify a spinner can be stopped and started again
 func TestRestart(t *testing.T) {
-	s := New(CharSets[4], 50*time.Millisecond)
-	var out syncBuffer
-	s.Writer = &out
+	s, out := withOutput(CharSets[4], 20*time.Millisecond)
+
 	s.Start()
-	s.Color("cyan")
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(75 * time.Millisecond)
 	s.Restart()
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(75 * time.Millisecond)
 	s.Stop()
-	time.Sleep(50 * time.Millisecond)
-	out.Lock()
-	defer out.Unlock()
+	time.Sleep(10 * time.Millisecond)
+
 	result := out.Bytes()
 	first := result[:len(result)/2]
-	secnd := result[len(result)/2:]
-	if string(first) != string(secnd) {
-		t.Errorf("Expected ==, got \n%#v != \n%#v", first, secnd)
+	second := result[len(result)/2:]
+	if !bytes.Equal(first, second) {
+		t.Errorf("expected restart output to match initial output. got=%q want=%q", first, second)
 	}
-	s = nil
 }
 
 // TestHookFunctions will verify that hook functions works as expected


### PR DESCRIPTION
Noticed that this test wasn't passing for me when running things earlier. If there's too much timing variance in execution it can throw false-positives at least in part due to the way the test is asserting correctness.

The current flow of the test is:

1. Create a spinner
2. Start spinner & sleep for a period
3. Restart spinner & sleep for another period
4. Stop spinner
5. Split the output bytes in half and compare them to one another

Even though the spinner successfully restarted the test can fail if the count is off and (I think) can also be exacerbated by ANSI codes.

I had done some larger WIP testing where I would strip the output of control characters with the idea being to compare the output spinner characters directly. Doing something like that wouldn't totally address for variance still. Changing to check that the subset of symbols written after the restart also exists in the original run could help. Or perhaps simply that there were even any characters written after restart?

