### PR TITLE
Move cursor to the beginning of the line before erasing

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -395,7 +395,7 @@ func (s *Spinner) UpdateCharSet(cs []string) {
 	s.mu.Unlock()
 }
 
-// erase deletes written characters.
+// erase deletes written characters on the current line.
 // Caller must already hold s.lock.
 func (s *Spinner) erase() {
 	n := utf8.RuneCountInString(s.lastOutput)
@@ -405,7 +405,14 @@ func (s *Spinner) erase() {
 		s.lastOutput = ""
 		return
 	}
-	fmt.Fprintf(s.Writer, "\033[K") // erases to end of line
+
+	// Taken from https://en.wikipedia.org/wiki/ANSI_escape_code:
+	// \r     - Carriage return - Moves the cursor to column zero
+	// \033[K - Erases part of the line. If n is 0 (or missing), clear from
+	// cursor to the end of the line. If n is 1, clear from cursor to beginning
+	// of the line. If n is 2, clear entire line. Cursor position does not
+	// change.
+	fmt.Fprintf(s.Writer, "\r\033[K")
 	s.lastOutput = ""
 }
 


### PR DESCRIPTION
The \033[K escape sequence signifies 'clear from cursor position to the
end of the line'. Without moving the cursor to the beggining of the line
first it results in no text being deleted. The behaviour of Carriage
Return (\r) in terminal emulators is not formally standardized but it is
generally interpreted as a move to the beginning of the line.

Tested on both Linux and Windows (cmd.exe, WSL2 and Windows Terminal).

Fixes https://github.com/briandowns/spinner/issues/123