### PR TITLE
Do not show colors in Windows CMD & Powershell

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -100,7 +100,8 @@ var validColors = map[string]bool{
 }
 
 // returns true if the OS is windows and the WT_SESSION env variable is set.
-var isWindowsTerminalOnWindows = len(os.Getenv("WT_SESSION")) > 0 && runtime.GOOS == "windows"
+var isWindows = runtime.OSOS == "windows"
+var isWindowsTerminalOnWindows = len(os.Getenv("WT_SESSION")) > 0 && isWindows
 
 // returns a valid color's foreground text color attribute
 var colorAttributeMap = map[string]color.Attribute{
@@ -280,6 +281,12 @@ func (s *Spinner) Start() {
 		// hides the cursor
 		fmt.Fprint(s.Writer, "\033[?25l")
 	}
+	// Disable colors for simple Windows CMD or Powershell
+	// as they can not recognize them
+	if isWindows && !isWindowsTerminalOnWindows {
+		color.NoColor = true
+	}
+
 	s.active = true
 	s.mu.Unlock()
 
@@ -304,7 +311,7 @@ func (s *Spinner) Start() {
 					}
 
 					var outColor string
-					if runtime.GOOS == "windows" {
+					if isWindows {
 						if s.Writer == os.Stderr {
 							outColor = fmt.Sprintf("\r%s%s%s", s.Prefix, s.chars[i], s.Suffix)
 						} else {


### PR DESCRIPTION
**What**
Does not show colors in simple Windows CMD or Powershell shells

**Why**
Before, even when using White color, you would get some random characters representing the colors
```
Something like:
[37m <spinner-here> [21m
```

**How has this been tested** 
I made the change and locally imported the package into the new solution which creates the spinner and sleeps for 10s.
Then I run it on:
- [x] CMD
- [x] Powershell
- [x] Windows Terminal (Powershell)
- [x] Windows Terminal [Ubuntu] to ensure that it works on all of them.