### PR TITLE
Consolidate the dependencies for the IsTerminal() API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	github.com/fatih/color v1.7.0
-	github.com/mattn/go-isatty v0.0.8
 	golang.org/x/term v0.1.0
 )
 
 require (
 	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.8 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 )

--- a/spinner.go
+++ b/spinner.go
@@ -29,7 +29,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
 )
 
@@ -502,7 +501,8 @@ func GenerateNumberSequence(length int) []string {
 
 // isRunningInTerminal check if the writer file descriptor is a terminal
 func isRunningInTerminal(s *Spinner) bool {
-	return isatty.IsTerminal(s.WriterFile.Fd())
+	fd := s.WriterFile.Fd()
+	return term.IsTerminal(int(fd))
 }
 
 func computeNumberOfLinesNeededToPrintString(linePrinted string) int {

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -158,7 +158,7 @@ func TestDisable(t *testing.T) {
 // TestHookFunctions will verify that hook functions works as expected
 func TestHookFunctions(t *testing.T) {
 	if fd := os.Stdout.Fd(); !term.IsTerminal(int(fd)) {
-		t.Log("not running in a termian")
+		t.Log("not running in a terminal")
 		return
 	}
 	s := New(CharSets[4], 50*time.Millisecond)

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
 )
 
 const baseWait = 3
@@ -73,7 +73,7 @@ func TestStart(t *testing.T) {
 
 // TestActive will verify we can tell when a spinner is running
 func TestActive(t *testing.T) {
-	if !isatty.IsTerminal(os.Stdout.Fd()) {
+	if fd := os.Stdout.Fd(); !term.IsTerminal(int(fd)) {
 		t.Log("not running in a terminal")
 		return
 	}
@@ -157,7 +157,7 @@ func TestDisable(t *testing.T) {
 
 // TestHookFunctions will verify that hook functions works as expected
 func TestHookFunctions(t *testing.T) {
-	if !isatty.IsTerminal(os.Stdout.Fd()) {
+	if fd := os.Stdout.Fd(); !term.IsTerminal(int(fd)) {
 		t.Log("not running in a termian")
 		return
 	}


### PR DESCRIPTION
The code was already using golang.org/x/term for the IsTerminal() API. It seems better to stick to packages from the golang.org domain, because they are likely to be more widely used than github.com/mattn/go-isatty, and one less dependency is always a good thing.

This can reduce the number of dependencies for consumers of github.com/briandowns/spinner, who may already have golang.org/x/term in their dependency chain.