### PR TITLE
Removed unused type 'Options'

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -221,14 +221,6 @@ func New(cs []string, d time.Duration, options ...Option) *Spinner {
 // a given configuration.
 type Option func(*Spinner)
 
-// Options contains fields to configure the spinner.
-type Options struct {
-	Color      string
-	Suffix     string
-	FinalMSG   string
-	HideCursor bool
-}
-
 // WithColor adds the given color to the spinner.
 func WithColor(color string) Option {
 	return func(s *Spinner) {


### PR DESCRIPTION
Such a helper type for the spinner's options would have been necessary if the `Option` functions were invoked before the `Spinner` object was instantiated.  However, in this case, the `Spinner` object is first instantiated with default values, which are then overwritten by running the `Option` functions.

In any case, there's certainly no need for the helper type to be exported as part of the API.

Fallout from 6e645a1cc3030179b9ffb069f796c213f69ed2e6